### PR TITLE
Fix function unloading

### DIFF
--- a/FunctionHandler.py
+++ b/FunctionHandler.py
@@ -45,7 +45,7 @@ def LoadFunction(name, loadAs=''):
         
 
 def UnloadFunction(name):
-    if name.lower in GlobalVars.functionCaseMapping.keys():
+    if name.lower() in GlobalVars.functionCaseMapping.keys():
         del GlobalVars.functions[GlobalVars.functionCaseMapping[name]]
         del GlobalVars.functionCaseMapping[name.lower()]
     else:


### PR DESCRIPTION
lower is a function, not a variable :P
At the moment it's looking if the function object 'lower' is in the case map dictionary, rather than if the lowercase name is.
