### PR TITLE
Update Twisted and remove argparse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 PyYAML==3.11
-Twisted==14.0.2
-argparse==1.2.2
+Twisted==15.0.0
 enum34==1.0.4
 pytimeparse>=1.1.0
 cobe==2.1.1


### PR DESCRIPTION
Twisted 15 is out now. Also, argparse is obsolete because it's included as of Python 2.7. Because the string formatting that's used is `{}` instead of `{<index>}`, Python 2.7 is already minimally required to run the code.